### PR TITLE
Changed frame_id from default to sbes

### DIFF
--- a/kingfisher_bringup/launch/library/sonar_nmea.launch
+++ b/kingfisher_bringup/launch/library/sonar_nmea.launch
@@ -5,6 +5,7 @@
     <node pkg="nmea_comms" type="serial_node" name="nmea_sonar_serial_node">
       <param name="port" value="$(optenv KINGFISHER_SONAR_PORT /dev/clearpath/sonar)"/>
       <param name="baud" value="$(optenv KINGFISHER_SONAR_BAUD 4800)"/>
+      <param name="frame_id" value="sbes"/>
     </node>
   </group>
 </launch>


### PR DESCRIPTION
Added a frame_id param to override the default of "navsat" defined in nmea_comms. An NMEA source that isn't navsat! =)
